### PR TITLE
Reduce package size by excluding unused 'deps' directory

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,10 +1,6 @@
-deps/*
-!deps/librdkafka.gyp
-!deps/librdkafka
-!deps/windows-install.*
+deps/
 .gitmodules
 Dockerfile
-deps/librdkafka/config.h
 build
 .github
 .vscode


### PR DESCRIPTION
The 'deps' directory in the node-rdkafka package is significantly large (around 98MB), constituting roughly 83% of the total package size. Seems like removing that directory is not affect the functionality.

This pull request proposes removing the 'deps' directory to decrease the package size.

**File size breakdown (before this change):**

Files:
 24K	./bench
 88K	./test
 16K	./util
 24K	./ci
 32K	./examples
128K	./lib
 98M	./deps
 18M	./build
 76K	./e2e
264K	./src
118M	.